### PR TITLE
PortalGun protection

### DIFF
--- a/src/ee/lutsu/alpha/mc/mytown/ChunkCoord.java
+++ b/src/ee/lutsu/alpha/mc/mytown/ChunkCoord.java
@@ -1,13 +1,55 @@
 package ee.lutsu.alpha.mc.mytown;
 
-public class ChunkCoord 
-{
-	public static int getCoord(double pos)
-	{
-		int i = (int)pos;
+public class ChunkCoord {
+	public int x;
+	public int z;
+
+	/**
+	 * Returns chunk coord given block coord
+	 * 
+	 * @param pos
+	 *            block coord (x or z)
+	 * @return
+	 */
+	public static int getCoord(double pos) {
+		int i = (int) pos;
 		if (i < 0 && pos != i)
 			i--;
-		
+
 		return i >> 4;
+	}
+
+	/**
+	 * Returns ChunkCoord given block coords
+	 * 
+	 * @param x
+	 *            block x coord
+	 * @param z
+	 *            block z coord
+	 * @return
+	 */
+	public static ChunkCoord getCoord(int x, int z) {
+		ChunkCoord chunk = new ChunkCoord();
+		chunk.x = getCoord(x);
+		chunk.z = getCoord(z);
+		return chunk;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		
+		if (obj instanceof ChunkCoord) {
+			ChunkCoord chunk = (ChunkCoord) obj;
+			if (chunk.x == x && chunk.z == z) {
+				return true;
+			}
+			return false;
+		}
+		return super.equals(obj);
+	}
+	
+	@Override
+	public int hashCode() {
+		return x << 8 + z;
 	}
 }

--- a/src/ee/lutsu/alpha/mc/mytown/event/prot/PortalGun.java
+++ b/src/ee/lutsu/alpha/mc/mytown/event/prot/PortalGun.java
@@ -1,82 +1,86 @@
 package ee.lutsu.alpha.mc.mytown.event.prot;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 
 import com.google.common.collect.Lists;
 
-import net.minecraft.entity.Entity;
-
 import ee.lutsu.alpha.mc.mytown.ChunkCoord;
-import ee.lutsu.alpha.mc.mytown.Log;
 import ee.lutsu.alpha.mc.mytown.MyTownDatasource;
 import ee.lutsu.alpha.mc.mytown.entities.Resident;
-import ee.lutsu.alpha.mc.mytown.entities.Town;
 import ee.lutsu.alpha.mc.mytown.entities.TownBlock;
 import ee.lutsu.alpha.mc.mytown.entities.TownSettingCollection.Permissions;
 import ee.lutsu.alpha.mc.mytown.event.ProtBase;
 import ee.lutsu.alpha.mc.mytown.event.ProtectionEvents;
 
-public class PortalGun extends ProtBase
-{
+public class PortalGun extends ProtBase {
 	public static PortalGun instance = new PortalGun();
-	
+
+	@SuppressWarnings("rawtypes")
 	Class clPortalBall = null;
 	List<String> systemOwnerNames = Lists.newArrayList("", "def", "coopA", "coopB");
-	
+
+	// Used to iterate over a central position and the 6 blocks surrounding it
+	private final static int[] xPos = { 0, 1, -1, 0, 0, 0, 0 };
+	private final static int[] zPos = { 0, 0, 0, 1, -1, 0, 0 };
+	private final static int[] yPos = { 0, 0, 0, 0, 0, 1, -1 };
+
 	@Override
-	public void load() throws Exception
-	{
+	public void load() throws Exception {
 		clPortalBall = Class.forName("portalgun.common.entity.EntityPortalBall");
 	}
-	
-	@Override
-	public boolean loaded() { return clPortalBall != null; }
-	@Override
-	public boolean isEntityInstance(Entity e) { return e.getClass() == clPortalBall; }
 
 	@Override
-	public String update(Entity e) throws Exception
-	{
-		if ((int)e.posX == (int)e.prevPosX && (int)e.posY == (int)e.prevPosY && (int)e.posZ == (int)e.prevPosZ) // didn't move
+	public boolean loaded() {
+		return clPortalBall != null;
+	}
+
+	@Override
+	public boolean isEntityInstance(Entity e) {
+		return e.getClass() == clPortalBall;
+	}
+
+	@Override
+	public String update(Entity e) throws Exception {
+
+		Vec3 currPos = Vec3.createVectorHelper(e.posX, e.posY, e.posZ);
+		Vec3 nextPos = Vec3.createVectorHelper(e.posX + e.motionX, e.posY + e.motionY, e.posZ + e.motionZ);
+		MovingObjectPosition collision = e.worldObj.rayTraceBlocks(currPos, nextPos);
+
+		// Not trying to make a portal yet
+		if (collision == null) {
 			return null;
-		
+		}
+
 		String owner = e.getDataWatcher().getWatchableObjectString(18);
-		
-		if (owner != null && !systemOwnerNames.contains(owner)) // not default portal
-		{
+
+		// not default portal
+		if (owner != null && !systemOwnerNames.contains(owner)) {
 			if (owner.endsWith("_A") || owner.endsWith("_B"))
 				owner = owner.substring(0, owner.length() - 2);
-			
+
 			Resident r = ProtectionEvents.instance.lastOwner = MyTownDatasource.instance.getResident(owner);
-		    if (r == null || !r.isOnline())
-		    	return "Owner " + owner + " not found or offline";
-		    
-			for (int ii = 0; ii < 5; ii++)
-			{
-			    int x = (int)(e.motionX / 5.0D * ii + e.posX);
-			    int y = (int)(e.motionY / 5.0D * ii + e.posY);
-			    int z = (int)(e.motionZ / 5.0D * ii + e.posZ);
+			if (r == null || !r.isOnline())
+				return "Owner " + owner + " not found or offline";
 
-			    if (!r.canInteract(x, y, z, Permissions.Build))
-			    	return "Cannot shoot portals in this town";
+			for (int i = 0; i < 7; i++) {
+				if (!r.canInteract(collision.blockX + xPos[i], collision.blockY + yPos[i], collision.blockZ + zPos[i],
+						Permissions.Build))
+					return "Cannot shoot portals in this town";
 			}
-		}
-		else
-		{
-			for (int ii = 0; ii < 5; ii++)
-			{
-			    int x = (int)(e.motionX / 5.0D * ii + e.posX);
-			    int y = (int)(e.motionY / 5.0D * ii + e.posY);
-			    int z = (int)(e.motionZ / 5.0D * ii + e.posZ);
+		} else {
+			Set<ChunkCoord> chunks = new HashSet<ChunkCoord>();
+			for (int i = 0; i < 5; i++) {
+				chunks.add(ChunkCoord.getCoord(collision.blockX + xPos[i], collision.blockZ + zPos[i]));
+			}
 
-			    int cx = ChunkCoord.getCoord(x);
-			    int cz = ChunkCoord.getCoord(z);
-			    
-				TownBlock b = MyTownDatasource.instance.getBlock(e.dimension, x, z);
+			for (ChunkCoord chunk : chunks) {
+				TownBlock b = MyTownDatasource.instance.getBlock(e.dimension, chunk.x, chunk.z);
 				if (b != null && b.town() != null)
 					return "Cannot use default portals in towns";
 			}
@@ -84,7 +88,12 @@ public class PortalGun extends ProtBase
 
 		return null;
 	}
-	
-	public String getMod() { return "PortalgunMod"; }
-	public String getComment() { return "Build check: EntityPortalBall. Disables non-owner balls completly in town"; }
+
+	public String getMod() {
+		return "PortalgunMod";
+	}
+
+	public String getComment() {
+		return "Build check: EntityPortalBall. Disables non-owner balls completly in town";
+	}
 }


### PR DESCRIPTION
Hey Legobear.

Protection against portal gun portals wasn't working so I went and changed it.
There were two problems:
1) if it was a default portal, getBlock was called with block x and z, while it should be called with chunk dimensions.
2) When shot from very close the update method is called only once, but it ends after checking if the entity is moving, skipping protection checks.

I've redid the whole update method, so it does permission checking only when the ball collides with something, that way in case number two the very first update call has a collision and ends up checking permissions.
A side effect is that portal balls can now fly through towns, as long as they land on an area where they are permitted to create a portal.

Hopefully this way requires less processing than the previous one, but not sure about that.

There's one slight bug though: due to checking permissions for all blocks around the collided one, portals may refuse to work one block away from a town chunk. I would have to know on which block the 2nd part of the portal will appear, to correct this.
