### PR TITLE
Fix return from mytown.cmd.sub.nation.CmdNationNew.getPermNode()

### DIFF
--- a/src/main/java/mytown/cmd/sub/nation/CmdNationNew.java
+++ b/src/main/java/mytown/cmd/sub/nation/CmdNationNew.java
@@ -25,7 +25,7 @@ public class CmdNationNew extends MyTownSubCommandAdapter {
 
 	@Override
 	public String getPermNode() {
-		return "nation";
+		return "mytown.cmd.nationnew";
 	}
 
 	@Override


### PR DESCRIPTION
Fixed permission node for command "/mytown nation new" so it reflects the documentation.
